### PR TITLE
Add alias to the openx adapter

### DIFF
--- a/modifications.md
+++ b/modifications.md
@@ -10,6 +10,7 @@ These are the ways in which the Guardian optimised build differs from the [gener
     * has an extra request parameter, `gmgt`, holding AppNexus targeting key-values
     * has a customised `pv` parameter, holding the Ophan-generated pageview ID
 * The [AppNexus adapter](https://github.com/guardian/Prebid.js/blob/master/modules/appnexusBidAdapter.js) has an alias `xhb` for Xaxis and the alias `and` for AppNexus direct.
+* The [OpenX adapter](https://github.com/guardian/Prebid.js/blob/master/modules/openxBidAdapter.js) has an alias `oxd` for OpenX direct, instead of via server-side header bidding.
 ## Analytics adapters
 * We have built two analytics adapters:
     * an [adapter](https://github.com/guardian/Prebid.js/blob/master/modules/guAnalyticsAdapter.js) to send analytics to the data lake

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -18,6 +18,7 @@ export function resetBoPixel() {
 
 export const spec = {
   code: BIDDER_CODE,
+  aliases: ['oxd'],
   supportedMediaTypes: SUPPORTED_AD_TYPES,
   isBidRequestValid: function (bidRequest) {
     if (utils.deepAccess(bidRequest, 'mediaTypes.banner') && bidRequest.params.delDomain) {


### PR DESCRIPTION
Add an alias to OpenX so that we can start calling them directly.

`oxd` = OpenX direct.

@guardian/commercial-dev 