### PR TITLE
Decrease TTL of IndexExchange bids

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -11,7 +11,7 @@ const BANNER_INSECURE_BID_URL = 'http://as.casalemedia.com/cygnus';
 const SUPPORTED_AD_TYPES = [BANNER];
 const ENDPOINT_VERSION = 7.2;
 const CENT_TO_DOLLAR_FACTOR = 100;
-const TIME_TO_LIVE = 35;
+const TIME_TO_LIVE = 10;
 const NET_REVENUE = true;
 
 // Always start by assuming the protocol is HTTPS. This way, it will work


### PR DESCRIPTION
Index have asked us to reduce the TTL of their bids to reduce the discrepancy between DFP and Index's own figures.
This is unlikely to have any effect, as it just means that any bid they make can be cached and reused inside Prebid for up to 10 ms, instead of 35 ms.