### PR TITLE
Ensure that only modules in modules.json are included in build

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -61,6 +61,21 @@ module.exports = {
 
     return modules;
   },
+
+  getModulesToInclude() {
+    let modules;
+    const moduleFile = 'modules.json';
+    try {
+      modules = JSON.parse(fs.readFileSync(moduleFile, 'utf8'));
+    } catch (e) {
+      throw new gutil.PluginError({
+        plugin: 'modules',
+        message: 'failed reading: ' + moduleFile
+      });
+    }
+    return modules;
+  },
+
   getModules: _.memoize(function(externalModules) {
     externalModules = externalModules || [];
     var internalModules;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,7 @@ function makeWebpackPkg() {
   var cloned = _.cloneDeep(webpackConfig);
   delete cloned.devtool;
 
-  var externalModules = helpers.getArgModules();
+  var externalModules = helpers.getModulesToInclude();
 
   const analyticsSources = helpers.getAnalyticsSources();
   const moduleSources = helpers.getModulePaths(externalModules);


### PR DESCRIPTION
By default, if you run `gulp build` you include all modules in the build, which can introduce strange errors as well as a much larger dependency than required.

This change ensures that even if you forget to include `--modules=modules.json` you will still only get the modules you expect in the build.
