### PR TITLE
Simplify babel config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5588,9 +5588,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001105",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001105.tgz",
-      "integrity": "sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg==",
+      "version": "1.0.30001223",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz",
+      "integrity": "sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
-    "@babel/plugin-proposal-optional-chaining": "^7.13.12",
     "@babel/preset-env": "^7.8.4",
     "@jsdevtools/coverage-istanbul-loader": "^3.0.3",
     "@wdio/browserstack-service": "^6.1.4",

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -66,11 +66,8 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
-              presets: [
-                ['@babel/preset-env', { targets: 'defaults' }]
-              ],
-              plugins: ['@babel/plugin-proposal-optional-chaining']
-            }
+              presets: [['@babel/preset-env', { targets: 'defaults' }]],
+            },
           },
         ],
       },


### PR DESCRIPTION
Small cleanup from #113.

Thanks @sndrs for pointing out that optional chaining is part of `present-env`.