### PR TITLE
Stop sending requests to `commercial/api/hb`

### DIFF
--- a/modules/guAnalyticsAdapter.js
+++ b/modules/guAnalyticsAdapter.js
@@ -131,16 +131,6 @@ function logEvents(events) {
   log('commercial', `Prebid.js events: ${logMsg}`, events);
 }
 
-analyticsAdapter.ajaxCall = function ajaxCall(data) {
-  const url = `${analyticsAdapter.context.ajaxUrl}/commercial/api/hb`;
-  const callback = (data) => logEvents(JSON.parse(data).hb_ev);
-  const options = {
-    method: 'POST',
-    contentType: 'text/plain; charset=utf-8'
-  };
-  ajax(url, callback(data), data, options);
-};
-
 function trackBidWon(args) {
   const event = {ev: 'bidwon'};
   setSafely(event, 'aid', args.auctionId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/prebid.js",
-  "version": "8.52.0-5",
+  "version": "8.52.0-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/prebid.js",
-      "version": "8.52.0-5",
+      "version": "8.52.0-6",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prebid.js",
-  "version": "8.52.0-5",
+  "version": "8.52.0-6",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "files": [


### PR DESCRIPTION
## Description of change
<!-- Describe the change proposed in this pull request -->

This PR stops sending requests to `/hb` endpoint as part of this work https://github.com/guardian/frontend/pull/27506. This should be merged first before merging the Frontend and https://github.com/guardian/platform/pull/1625 PRs. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
