### PR TITLE
Restart sending requests to the commercial/api/hb endpoint

### DIFF
--- a/modules/guAnalyticsAdapter.js
+++ b/modules/guAnalyticsAdapter.js
@@ -131,6 +131,16 @@ function logEvents(events) {
   log('commercial', `Prebid.js events: ${logMsg}`, events);
 }
 
+analyticsAdapter.ajaxCall = function ajaxCall(data) {
+  const url = `${analyticsAdapter.context.ajaxUrl}/commercial/api/hb`;
+  const callback = (data) => logEvents(JSON.parse(data).hb_ev);
+  const options = {
+    method: 'POST',
+    contentType: 'text/plain; charset=utf-8'
+  };
+  ajax(url, callback(data), data, options);
+};
+
 function trackBidWon(args) {
   const event = {ev: 'bidwon'};
   setSafely(event, 'aid', args.auctionId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/prebid.js",
-  "version": "8.52.0-6",
+  "version": "8.52.0-7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/prebid.js",
-      "version": "8.52.0-6",
+      "version": "8.52.0-7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prebid.js",
-  "version": "8.52.0-6",
+  "version": "8.52.0-7",
   "description": "Header Bidding Management Library",
   "main": "src/prebid.js",
   "files": [


### PR DESCRIPTION
## Description of change
Reverses [this PR](https://github.com/guardian/Prebid.js/pull/159) and bumps the version. This previous change has affected some data jobs so we're reversing it.